### PR TITLE
Fix test compatibility with Oracle Instant Client 23

### DIFF
--- a/tests/array_bind_001.phpt
+++ b/tests/array_bind_001.phpt
@@ -63,7 +63,7 @@ var_dump($array);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: oci_bind_array_by_name(): OCI-21560: argument 3 is null, invalid, or out of range in %s on line %d
+Warning: oci_bind_array_by_name(): OCI-21560: argument%S 3 is null, invalid, or out of range in %s on line %d
 
 Warning: oci_execute(): ORA-%r(01008|57000)%r: %s in %s on line %d
 array(1) {

--- a/tests/array_bind_010.phpt
+++ b/tests/array_bind_010.phpt
@@ -24,7 +24,7 @@ var_dump($array);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: oci_bind_array_by_name(): ORA-01036: illegal variable name/number in %s on line %d
+Warning: oci_bind_array_by_name(): ORA-01036: %r(illegal variable name\/number|unrecognized bind variable :c1 passed to the bind call)%r in %s on line %d
 array(5) {
   [0]=>
   string(1) "1"

--- a/tests/define2.phpt
+++ b/tests/define2.phpt
@@ -98,5 +98,5 @@ file md5:80bb3201e2a8bdcb8ab3e1a44a82bb8a
 Test 4 - wrong type
 bool(true)
 
-Warning: oci_fetch(): ORA-00932: inconsistent datatypes%s on line %d
+Warning: oci_fetch(): ORA-00932: %r(inconsistent datatypes|expression is of data type)%r%s on line %d
 Done

--- a/tests/extauth_01.phpt
+++ b/tests/extauth_01.phpt
@@ -169,7 +169,7 @@ array(4) {
 bool(false)
 Test 9
 
-Warning: oci_connect(): ORA-%d: TNS:%s in %s on line %d
+Warning: oci_connect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r in %s on line %d
 array(4) {
   ["code"]=>
   int(%d)
@@ -183,7 +183,7 @@ array(4) {
 bool(false)
 Test 10
 
-Warning: oci_connect(): ORA-%d: TNS:%s in %s on line %d
+Warning: oci_connect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r in %s on line %d
 array(4) {
   ["code"]=>
   int(%d)

--- a/tests/extauth_02.phpt
+++ b/tests/extauth_02.phpt
@@ -169,7 +169,7 @@ array(4) {
 bool(false)
 Test 9
 
-Warning: oci_new_connect(): ORA-%d: TNS:%s %s on line %d
+Warning: oci_new_connect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r %s on line %d
 array(4) {
   ["code"]=>
   int(%d)
@@ -183,7 +183,7 @@ array(4) {
 bool(false)
 Test 10
 
-Warning: oci_new_connect(): ORA-%d: TNS:%s %s on line %d
+Warning: oci_new_connect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r %s on line %d
 array(4) {
   ["code"]=>
   int(%d)

--- a/tests/extauth_03.phpt
+++ b/tests/extauth_03.phpt
@@ -169,7 +169,7 @@ array(4) {
 bool(false)
 Test 9
 
-Warning: oci_pconnect(): ORA-%d: TNS:%s in %s on line %d
+Warning: oci_pconnect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r in %s on line %d
 array(4) {
   ["code"]=>
   int(%d)
@@ -183,7 +183,7 @@ array(4) {
 bool(false)
 Test 10
 
-Warning: oci_pconnect(): ORA-%d: TNS:%s in %s on line %d
+Warning: oci_pconnect(): ORA-%d: %r(TNS:%s|Cannot connect to database\. Cannot find alias d)%r in %s on line %d
 array(4) {
   ["code"]=>
   int(%d)


### PR DESCRIPTION
Oracle seems to have changed some error messages in Instant Client 23, which makes some tests fail. This PR makes the tests compatible with 23 and below. I tested this with IC 21 and 23 on database 19c. Some tests were skipped (e.g. due to missing admin privileges in the database), so this might not be exhaustive.