### PR TITLE
Fail earlier with older PHPs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -443,7 +443,7 @@ Oracle's standard cross-version connectivity applies.  For example, PHP OCI8 lin
  <dependencies>
   <required>
    <php>
-    <min>8.1.0</min>
+    <min>8.2.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
Bump the min PHP version in package.xml so the install fails earlier when installating on an unsupported PHP version.

Without this change, the install will fail during compilation due to the `#error` version checks in https://github.com/php/pecl-database-oci8/blob/main/oci8.c#L43-L56